### PR TITLE
Add GitHub Action to build and publish the docker image

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,53 @@
+name: Publish Docker image
+# To SDM-TIB GitHub Container Registry
+# https://github.com/orgs/SDM-TIB/packages
+on:
+  workflow_dispatch:
+  push:
+    # Publish `develop` as Docker `latest` image.
+    branches:
+      - develop
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  release:
+    types:
+      - created
+
+env:
+  IMAGE_NAME: rdfizer
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "develop" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,7 +6,7 @@ on:
   push:
     # Publish `develop` as Docker `latest` image.
     branches:
-      - develop
+      - master
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*


### PR DESCRIPTION
To make it easier to reuse the tool with Docker we can easily publish it to the GitHub Container Registry (which is completely free for open source projects)

The GitHub Action workflow will publish a new image when:
* a new latest image to every push to develop (you can change it to master if you prefer, but you'll need to merge the Dockerfile in the master branch 
* or when you create a new tag/release (tag starting with v, e.g. v0.0.1)

You can check that it works by checking the image this workflow published on my user: https://github.com/vemonet/SDM-RDFizer/pkgs/container/rdfizer