### PR TITLE
use Graph.parse() to comply with rdflib 6.2.0

### DIFF
--- a/rdfizer/rdfizer/semantify.py
+++ b/rdfizer/rdfizer/semantify.py
@@ -595,7 +595,7 @@ def mapping_parser(mapping_file):
 	mapping_graph = rdflib.Graph()
 
 	try:
-		mapping_graph.load(mapping_file, format='n3')
+		mapping_graph.parse(mapping_file, format='n3')
 	except Exception as n3_mapping_parse_exception:
 		print(n3_mapping_parse_exception)
 		print('Could not parse {} as a mapping file'.format(mapping_file))


### PR DESCRIPTION
In version 6.2.0 of rdflib methods like `Graph.load()` were removed. They were marked as deprecated before and initially scheduled for removal in version 6.0.0. This PR changes the use of `Graph.load()` to `Graph.parse()` which should be used instead.