### PR TITLE
Relax Version Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Flask
 isodate==0.6.0
-pyparsing==2.2.0
+pyparsing>=2.2.0
 rdflib
-six==1.11.0
+six>=1.11.0
 mysql-connector-python==8.0.22
 psycopg2-binary
 pandas


### PR DESCRIPTION
The exact requirements of
```
pyparsing==2.2.0
six==1.11.0
```
are too restrictive for most projects.

In my small test, the RDFizer seems to work fine with newer versions of the libraries. I tested with pyparsing 3.0.9 and six 1.16.0.

**Note:**
While you might want to set specific versions for the development and to be installed in the Docker container, you should specify minimal requirements for the library published at PyPI. Additionally, there is no need to install Flask when using the RDFizer as a library, is there?