### PR TITLE
rdfizer: import psycopg2

### DIFF
--- a/rdfizer/rdfizer/semantify.py
+++ b/rdfizer/rdfizer/semantify.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import time
 import json
 import xml.etree.ElementTree as ET
-#import psycopg2
+import psycopg2
 import pandas as pd
 from .functions import *
 


### PR DESCRIPTION
PostgreSQL is broken in 4.6.2 because the PostgreSQL client library is not imported.

Fixes #90 