### PR TITLE
[Feature] Log Errors to File

### DIFF
--- a/rdfizer/rdfizer/__init__.py
+++ b/rdfizer/rdfizer/__init__.py
@@ -1,16 +1,11 @@
-import os
-import re
 import csv
-import sys
 import rdflib
 from rdflib.plugins.sparql import prepareQuery
 from configparser import ConfigParser, ExtendedInterpolation
-import traceback
 from mysql import connector
 from concurrent.futures import ThreadPoolExecutor
 import time
 import json
-import xml.etree.ElementTree as ET
 import psycopg2
 import pandas as pd
 from .functions import *
@@ -20,7 +15,6 @@ try:
 except:
 	from .triples_map import TriplesMap as tm	
 
-import tracemalloc
 # Work in the rr:sqlQuery (change mapping parser query, add sqlite3 support, etc)
 # Work in the "when subject is empty" thing (uuid.uuid4(), dependency graph over the ) 
 


### PR DESCRIPTION
When executing several mapping files, it can be hard to see if an error occurred in one of them. This PR adds a logger to the SDM-RDFizer. Logs of all levels are streamed to the console to keep the current output. Additionally, logs of the levels `logging.ERROR` and above are stored in an error log. The default path is `error.log`. The path of the error log can be changed by passing a second argument to the `semantify()` method. I didn't change all prints to use the logger; only the errors are logged so far.