### PR TITLE
Allow newer Versions of mysql-connector-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ isodate==0.6.0
 pyparsing>=2.2.0
 rdflib
 six>=1.11.0
-mysql-connector-python==8.0.22
+mysql-connector-python>=8.0.22
 psycopg2-binary
 pandas


### PR DESCRIPTION
This PR relaxes the version constraint on the `mysql-connector-python` library. It was fixed to `8.0.22` but now allows all versions from said version.